### PR TITLE
Try implementing place with rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ mkmf.log
 *.gem
 .ruby-gemset
 .ruby-version
+
+
+#Added by cargo
+#
+#already existing elements are commented out
+
+/target
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "easy-box-packer"
+version = "0.1.0"
+authors = ["michael groble <mike@groble.me>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rutie = "0.7.0"
+
+[lib]
+name = "rutie_box_packer"
+crate-type = ["dylib"]

--- a/easy-box-packer.gemspec
+++ b/easy-box-packer.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary      = '3D bin-packing with weight limit using first-fit decreasing algorithm and empty maximal spaces'
   s.files        = Dir['LICENSE.txt', 'README.md', 'easy-box-packer.rb']
   s.require_path = '.'
+  s.add_dependency 'rutie', '~> 0.0.4'
   s.add_development_dependency 'rspec', '~> 3.1', '>= 3.1.0'
   s.add_development_dependency 'pry'
 end

--- a/easy-box-packer.rb
+++ b/easy-box-packer.rb
@@ -1,3 +1,9 @@
+require 'rutie'
+
+module RustBoxPacker
+  Rutie.new(:rutie_box_packer).init 'Init_rust_packer', File.expand_path('./target')
+end
+
 module EasyBoxPacker
   class << self
     def pack(container:, items:)
@@ -157,37 +163,7 @@ module EasyBoxPacker
     end
 
     def place(item, space)
-      item_length, item_width, item_height = item[:dimensions].sort.reverse
-
-      permutations = [
-        [item_width, item_height, item_length],
-        [item_width, item_length, item_height],
-        [item_height, item_width, item_length],
-        [item_height, item_length, item_width],
-        [item_length, item_width, item_height],
-        [item_length, item_height, item_width]
-      ]
-
-      possible_rotations_and_margins = []
-
-      permutations.each do |perm|
-        # Skip if the item does not fit with this orientation
-        next unless perm[0] <= space[:dimensions][0] &&
-          perm[1] <= space[:dimensions][1] &&
-          perm[2] <= space[:dimensions][2]
-
-        possible_margin   = [space[:dimensions][0] - perm[0], space[:dimensions][1] - perm[1], space[:dimensions][2] - perm[2]]
-        possible_rotations_and_margins << { margin: possible_margin, rotation: perm }
-      end
-
-      # select rotation with smallest margin
-      final = possible_rotations_and_margins.sort_by { |a| a[:margin].sort }.first
-      return unless final
-      return {
-        dimensions: final[:rotation],
-        position: space[:position],
-        weight: item[:weight].to_f
-      }
+      RustPacker.place(item, space)
     end
 
     def break_up_space(space, placement)

--- a/pack_benchmark.rb
+++ b/pack_benchmark.rb
@@ -1,0 +1,9 @@
+require 'easy-box-packer'
+require 'benchmark'
+
+puts Benchmark.measure {
+  EasyBoxPacker.pack(
+    container: { dimensions: [200, 300, 400], weight_limit: 5000 },
+    items: 5000.times.map {|_i| { dimensions: 3.times.map { Random.random_number(14..22) } , weight: Random.random_number(0.5..1.5) } }
+  )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,92 @@
+extern crate rutie;
+
+use rutie::{Class, Object, Hash, Float, Fixnum, NilClass, Array, Symbol, AnyObject, VM};
+
+rutie::class!(RustPacker);
+
+fn to_dimension(rb_dimension: &AnyObject) -> f64 {
+    match rb_dimension.try_convert_to::<Fixnum>() {
+        Ok(i) => i.to_i64() as f64,
+        Err(_) => rb_dimension.try_convert_to::<Float>().unwrap().to_f64()
+    }
+}
+
+fn to_3d_array(rb_array : &AnyObject) -> [f64; 3] {
+    let array = rb_array.try_convert_to::<Array>().unwrap();
+    [
+        to_dimension(&array.at(0)),
+        to_dimension(&array.at(1)),
+        to_dimension(&array.at(2)),
+    ]
+}
+
+struct RotationAndMargin<'a> {
+    rotation: &'a[f64; 3],
+    smallest_margin: f64
+}
+
+rutie::methods!(
+    RustPacker,
+    _itself,
+
+    fn place(item: Hash, space: Hash) -> AnyObject {
+        let item_hash = item.unwrap();
+        let space_hash = space.unwrap();
+        let space_dimensions = to_3d_array(&space_hash.at(&Symbol::new("dimensions")));
+        let mut item_dimensions = to_3d_array(&item_hash.at(&Symbol::new("dimensions")));
+        item_dimensions.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        item_dimensions.reverse();
+
+        let permutations : [[f64; 3]; 6] = [
+            [item_dimensions[1], item_dimensions[2], item_dimensions[0]],
+            [item_dimensions[1], item_dimensions[0], item_dimensions[2]],
+            [item_dimensions[2], item_dimensions[1], item_dimensions[0]],
+            [item_dimensions[2], item_dimensions[0], item_dimensions[1]],
+            [item_dimensions[0], item_dimensions[1], item_dimensions[2]],
+            [item_dimensions[0], item_dimensions[2], item_dimensions[1]]
+        ];
+
+        let mut possible_rotations_and_margins : Vec<RotationAndMargin> = Vec::with_capacity(6);
+
+        for rotation in permutations.iter() {
+            if rotation[0] > space_dimensions[0] || rotation[1] > space_dimensions[1] || rotation[2] > space_dimensions[2] {
+                continue;
+            }
+            let mut possible_margin = [
+                space_dimensions[0] - rotation[0],
+                space_dimensions[1] - rotation[1],
+                space_dimensions[2] - rotation[2]
+            ];
+            let smallest_margin = possible_margin[0].min(possible_margin[1]).min(possible_margin[2]);
+            possible_rotations_and_margins.push(
+                RotationAndMargin { rotation, smallest_margin }
+            );
+        }
+
+        if possible_rotations_and_margins.len() == 0 {
+            return AnyObject::from(NilClass::new().value());
+        }
+
+        let mut result = Hash::new();
+
+        possible_rotations_and_margins.sort_by(|a, b| a.smallest_margin.partial_cmp(&b.smallest_margin).unwrap());
+
+        let mut rotation = Array::new();
+        rotation.push(Float::new(possible_rotations_and_margins[0].rotation[0]));
+        rotation.push(Float::new(possible_rotations_and_margins[0].rotation[1]));
+        rotation.push(Float::new(possible_rotations_and_margins[0].rotation[2]));
+        result.store(Symbol::new("dimensions"), rotation);
+        result.store(Symbol::new("position"), space_hash.at(&Symbol::new("dimensions")));
+        result.store(Symbol::new("weight"), item_hash.at(&Symbol::new("weight")));
+
+        AnyObject::from(result.value())
+    }
+);
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub extern "C" fn Init_rust_packer() {
+    Class::new("RustPacker", None).define(|itself| {
+        itself.def_self("place", place);
+    });
+}


### PR DESCRIPTION
Uses rutie to implement part of the logic with rust.

Note master ruby has failures in three test cases and i didn't try to fix them:
  1) .pack should eql 2, 3, and 5
  2) .find_smallest_container case 7
  3) .find_smallest_container case 10

Benchmark shows just implementing `place` slows things down:

with ruby master branch:
```
bundle exec ruby pack_benchmark.rb 
 23.859085   0.087064  23.946149 ( 24.051686)
```
on rutie branch:
```
bundle exec ruby pack_benchmark.rb 
 30.325879   0.068634  30.394513 ( 30.447325)
```
